### PR TITLE
Add CFAR analysis CLI and shared CFAR/common helpers; integrate into baseline detector

### DIFF
--- a/analysis/test_clock_recovery/fsk_cfar.py
+++ b/analysis/test_clock_recovery/fsk_cfar.py
@@ -1,0 +1,82 @@
+"""CFAR helpers shared between baseline decode and analysis tooling."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class CfarWindowBands:
+    idx_start: int
+    idx_end: int
+    idx_center: int
+    stat: float
+    threshold: float
+    alpha: float
+    noise_mean: float
+    e0: float
+    e1: float
+    detection_bins: np.ndarray
+    guard_bins: np.ndarray
+    noise_bins: np.ndarray
+    detection_vals: np.ndarray
+    guard_vals: np.ndarray
+    noise_vals: np.ndarray
+
+
+def ca_cfar_alpha(pfa: float, ntrain: int, m_sig: int = 1) -> float:
+    if ntrain <= 0:
+        return float("inf")
+    ntrain_eff = max(4, min(ntrain, 256))
+    return ntrain_eff * m_sig * (pfa ** (-1.0 / ntrain_eff) - 1.0)
+
+
+def analyze_cfar_window(
+    seg_fft_power: np.ndarray,
+    k0: int,
+    k1: int,
+    guard_bins: int,
+    pfa: float,
+    m_sig: int = 1,
+    threshold_scale: float = 10.0,
+) -> dict:
+    n = seg_fft_power.size
+    detect_bins = np.array([k0, k1], dtype=np.int64)
+
+    guard_mask = np.zeros(n, dtype=bool)
+    for k in detect_bins:
+        lo = max(k - guard_bins, 0)
+        hi = min(k + guard_bins, n - 1)
+        guard_mask[lo : hi + 1] = True
+
+    noise_mask = ~guard_mask
+    noise_mask[0] = False
+
+    detection_vals = seg_fft_power[detect_bins]
+    guard_vals = seg_fft_power[guard_mask]
+    noise_vals = seg_fft_power[noise_mask]
+
+    e0 = float(seg_fft_power[k0])
+    e1 = float(seg_fft_power[k1])
+    stat = e0 + e1
+    noise_mean = float(np.mean(noise_vals)) if noise_vals.size else 1e-12
+    ntrain = int(np.sum(noise_mask))
+    alpha = ca_cfar_alpha(pfa, ntrain, m_sig=m_sig)
+    threshold = alpha * noise_mean * threshold_scale
+
+    return {
+        "stat": stat,
+        "threshold": float(threshold),
+        "alpha": float(alpha),
+        "noise_mean": noise_mean,
+        "e0": e0,
+        "e1": e1,
+        "detection_bins": detect_bins,
+        "guard_bins": np.flatnonzero(guard_mask),
+        "noise_bins": np.flatnonzero(noise_mask),
+        "detection_vals": detection_vals,
+        "guard_vals": guard_vals,
+        "noise_vals": noise_vals,
+    }

--- a/analysis/test_clock_recovery/fsk_cfar_cli.py
+++ b/analysis/test_clock_recovery/fsk_cfar_cli.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+try:
+    import plotly.graph_objects as go
+    from plotly.subplots import make_subplots
+except ImportError:
+    go = None
+    make_subplots = None
+
+import fsk_baseline as fsk
+from fsk_cfar import analyze_cfar_window, ca_cfar_alpha
+from fsk_common import now_iso_utc, read_wav, save_json
+
+
+def _to_sample(v_time: float | None, fs: int, default: int) -> int:
+    if v_time is None:
+        return default
+    return int(round(v_time * fs))
+
+
+def _analysis_bounds(args, nsamp: int, fs: int) -> tuple[int, int, int]:
+    start = args.start_sample if args.start_sample is not None else _to_sample(args.start_time, fs, 0)
+    end = args.end_sample if args.end_sample is not None else _to_sample(args.end_time, fs, nsamp)
+
+    if args.center_sample is not None or args.center_time is not None:
+        center = args.center_sample if args.center_sample is not None else _to_sample(args.center_time, fs, 0)
+        span = args.span_samples if args.span_samples is not None else _to_sample(args.span_time, fs, fs)
+        half = max(1, span // 2)
+        start = max(0, center - half)
+        end = min(nsamp, center + half)
+    else:
+        center = (start + end) // 2
+
+    start = max(0, min(start, nsamp))
+    end = max(start + 1, min(end, nsamp))
+    center = max(start, min(center, end - 1))
+    return start, end, center
+
+
+def run_analysis(args):
+    fs_file, x = read_wav(Path(args.wav))
+    fs = fs_file if args.fs <= 0 else args.fs
+    if fs != fs_file:
+        print(f"[WARN] WAV fs={fs_file}; using --fs={fs} for analysis math.")
+
+    cfg = fsk.FSKConfig(fs=fs, baud=args.baud, f0=args.f0, f1=args.f1)
+    meta = fsk.check_params(cfg)
+
+    start, end, center = _analysis_bounds(args, x.size, fs)
+    x_slice = x[start:end]
+    xa = fsk.analytic_signal_fft(x_slice)
+
+    Nw = args.win_symbols * meta.sps
+    hop = args.hop_symbols * meta.sps
+    if Nw > xa.size:
+        raise ValueError("Analysis slice shorter than CFAR window. Increase span or reduce win-symbols.")
+
+    k0 = int(round(cfg.f0 * Nw / fs))
+    k1 = int(round(cfg.f1 * Nw / fs))
+
+    rows = []
+    idx = 0
+    while idx + Nw <= xa.size:
+        seg = xa[idx : idx + Nw]
+        P = (np.fft.fft(seg) * np.conj(np.fft.fft(seg))).real
+        cfar = analyze_cfar_window(P, k0, k1, args.guard_bins, args.pfa, m_sig=1, threshold_scale=args.threshold_scale)
+        center_idx = start + idx + (Nw // 2)
+        rows.append({
+            "idx_start": start + idx,
+            "idx_end": start + idx + Nw,
+            "idx_center": center_idx,
+            "time_center_s": center_idx / fs,
+            "stat": cfar["stat"],
+            "threshold": cfar["threshold"],
+            "alpha": cfar["alpha"],
+            "noise_mean": cfar["noise_mean"],
+            "e0": cfar["e0"],
+            "e1": cfar["e1"],
+            "detect_mean": float(np.mean(cfar["detection_vals"])),
+            "guard_mean": float(np.mean(cfar["guard_vals"])) if cfar["guard_vals"].size else 0.0,
+            "noise_band_mean": float(np.mean(cfar["noise_vals"])) if cfar["noise_vals"].size else 0.0,
+            "cfar": cfar,
+        })
+        idx += hop
+
+    centers = np.array([r["idx_center"] for r in rows])
+    focus_i = int(np.argmin(np.abs(centers - center)))
+    focus = rows[focus_i]
+
+    base = Path(args.out_base) if args.out_base else Path(args.wav).with_suffix(".cfar")
+    base.parent.mkdir(parents=True, exist_ok=True)
+
+    summary_json = {
+        "timestamp": now_iso_utc(),
+        "wav": args.wav,
+        "analysis_region": {
+            "start_sample": start,
+            "end_sample": end,
+            "center_sample": center,
+            "start_time_s": start / fs,
+            "end_time_s": end / fs,
+            "center_time_s": center / fs,
+        },
+        "config": {
+            "fs": fs,
+            "baud": args.baud,
+            "f0": args.f0,
+            "f1": args.f1,
+            "pfa": args.pfa,
+            "guard_bins": args.guard_bins,
+            "win_symbols": args.win_symbols,
+            "hop_symbols": args.hop_symbols,
+            "threshold_scale": args.threshold_scale,
+        },
+        "focus_window": {
+            "window_index": focus_i,
+            "idx_start": focus["idx_start"],
+            "idx_end": focus["idx_end"],
+            "idx_center": focus["idx_center"],
+            "stat": focus["stat"],
+            "threshold": focus["threshold"],
+            "alpha": focus["alpha"],
+            "noise_mean": focus["noise_mean"],
+        },
+        "num_windows": len(rows),
+    }
+
+    save_json(base.with_suffix(".json"), summary_json)
+
+    with open(base.with_suffix(".windows.csv"), "w") as fh:
+        fh.write("win_idx,idx_start,idx_end,idx_center,time_center_s,stat,threshold,alpha,noise_mean,e0,e1,detect_mean,guard_mean,noise_band_mean\n")
+        for i, r in enumerate(rows):
+            fh.write(
+                f"{i},{r['idx_start']},{r['idx_end']},{r['idx_center']},{r['time_center_s']:.9f},{r['stat']:.9f},{r['threshold']:.9f},{r['alpha']:.9f},{r['noise_mean']:.9f},{r['e0']:.9f},{r['e1']:.9f},{r['detect_mean']:.9f},{r['guard_mean']:.9f},{r['noise_band_mean']:.9f}\n"
+            )
+
+    cfar = focus["cfar"]
+    with open(base.with_suffix(".focus_bins.csv"), "w") as fh:
+        fh.write("bin,power,band\n")
+        for b, v in zip(cfar["noise_bins"], cfar["noise_vals"]):
+            fh.write(f"{int(b)},{float(v):.9f},noise\n")
+        for b, v in zip(cfar["guard_bins"], cfar["guard_vals"]):
+            fh.write(f"{int(b)},{float(v):.9f},guard\n")
+        for b, v in zip(cfar["detection_bins"], cfar["detection_vals"]):
+            fh.write(f"{int(b)},{float(v):.9f},detect\n")
+
+    if args.plots != "none" and go is not None and make_subplots is not None:
+        fig = make_subplots(rows=3, cols=1, vertical_spacing=0.08, subplot_titles=(
+            "CFAR statistic vs threshold",
+            "Focus window FFT bins by CFAR band",
+            "alpha vs Pfa",
+        ))
+        t = np.array([r["idx_center"] / fs for r in rows])
+        fig.add_trace(go.Scatter(x=t, y=[r["stat"] for r in rows], name="stat", mode="lines+markers"), row=1, col=1)
+        fig.add_trace(go.Scatter(x=t, y=[r["threshold"] for r in rows], name="threshold", mode="lines+markers"), row=1, col=1)
+        fig.add_vline(x=focus["idx_center"] / fs, line_dash="dot", line_color="black", row=1, col=1)
+
+        fig.add_trace(go.Scatter(x=cfar["noise_bins"], y=cfar["noise_vals"], name="noise", mode="markers", marker=dict(size=5)), row=2, col=1)
+        fig.add_trace(go.Scatter(x=cfar["guard_bins"], y=cfar["guard_vals"], name="guard", mode="markers", marker=dict(size=6)), row=2, col=1)
+        fig.add_trace(go.Scatter(x=cfar["detection_bins"], y=cfar["detection_vals"], name="detect", mode="markers", marker=dict(size=9, symbol="diamond")), row=2, col=1)
+
+        pfa_vals = np.logspace(np.log10(args.pfa_min), np.log10(args.pfa_max), args.pfa_points)
+        ntrain = int(cfar["noise_bins"].size)
+        fig.add_trace(go.Scatter(x=pfa_vals, y=[ca_cfar_alpha(p, ntrain, m_sig=1) for p in pfa_vals], name="alpha m=1"), row=3, col=1)
+        fig.add_trace(go.Scatter(x=pfa_vals, y=[ca_cfar_alpha(p, ntrain, m_sig=2) for p in pfa_vals], name="alpha m=2"), row=3, col=1)
+        fig.update_xaxes(type="log", row=3, col=1, title_text="Pfa")
+        fig.update_yaxes(title_text="alpha", row=3, col=1)
+        fig.update_xaxes(title_text="time (s)", row=1, col=1)
+        fig.update_xaxes(title_text="FFT bin", row=2, col=1)
+        fig.update_layout(title="FSK CFAR Analysis", height=1000)
+
+        if args.plots == "html":
+            fig.write_html(str(base.with_suffix(".plot.html")), include_plotlyjs="cdn", full_html=True)
+        else:
+            fig.write_image(str(base.with_suffix(".plot.png")), scale=2)
+
+    print(f"Analysis outputs written with base: {base}")
+
+
+def parse_args(argv=None):
+    p = argparse.ArgumentParser(description="CFAR analysis CLI for FSK packet detector")
+    p.add_argument("--wav", required=True)
+    p.add_argument("--out-base", default=None)
+    p.add_argument("--fs", type=int, default=0, help="Override sample rate (0 = WAV rate)")
+    p.add_argument("--baud", type=int, default=100)
+    p.add_argument("--f0", type=float, default=1000.0)
+    p.add_argument("--f1", type=float, default=2000.0)
+    p.add_argument("--pfa", type=float, default=1e-3)
+    p.add_argument("--win-symbols", type=int, default=2)
+    p.add_argument("--hop-symbols", type=int, default=1)
+    p.add_argument("--guard-bins", type=int, default=2)
+    p.add_argument("--threshold-scale", type=float, default=10.0)
+
+    p.add_argument("--start-time", type=float, default=None)
+    p.add_argument("--end-time", type=float, default=None)
+    p.add_argument("--center-time", type=float, default=None)
+    p.add_argument("--span-time", type=float, default=0.5)
+    p.add_argument("--start-sample", type=int, default=None)
+    p.add_argument("--end-sample", type=int, default=None)
+    p.add_argument("--center-sample", type=int, default=None)
+    p.add_argument("--span-samples", type=int, default=None)
+
+    p.add_argument("--pfa-min", type=float, default=1e-7)
+    p.add_argument("--pfa-max", type=float, default=1e-1)
+    p.add_argument("--pfa-points", type=int, default=60)
+    p.add_argument("--plots", choices=["none", "html", "png"], default="html")
+    return p.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    run_analysis(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/test_clock_recovery/fsk_cli.py
+++ b/analysis/test_clock_recovery/fsk_cli.py
@@ -1,51 +1,15 @@
 #!/usr/bin/env python3
-import argparse, json, sys, os, math, datetime
+import argparse, json, sys, os, math
 from pathlib import Path
 import numpy as np
 
-try:
-    import soundfile as sf
-except ImportError:
-    sf = None
 try:
     import plotly.io as pio
 except ImportError:
     pio = None
 
 import fsk_baseline as fsk
-
-
-def _now_iso():
-    # Use timezone-aware UTC (avoids deprecation warning for utcnow)
-    ts = datetime.datetime.now(datetime.UTC)
-    # Ensure trailing 'Z' (strip offset)
-    return ts.isoformat().replace("+00:00", "Z")
-
-
-def write_wav(path: Path, data: np.ndarray, fs: int):
-    if sf is None:
-        from scipy.io import wavfile
-        wavfile.write(str(path), fs, data.astype(np.float32))
-    else:
-        sf.write(str(path), data.astype(np.float32), fs)
-
-
-def read_wav(path: Path):
-    if sf is None:
-        from scipy.io import wavfile
-        fs, x = wavfile.read(str(path))
-        if x.dtype != np.float32:
-            x = x.astype(np.float32) / np.max(np.abs(x))
-    else:
-        x, fs = sf.read(str(path), dtype="float32")
-        if x.ndim > 1:
-            x = x[:, 0]
-    return fs, x.astype(np.float32)
-
-
-def save_json(path: Path, obj):
-    with open(path, "w") as fh:
-        json.dump(obj, fh, indent=2)
+from fsk_common import now_iso_utc, write_wav, read_wav, save_json
 
 
 def build_tx_signal(cfg: fsk.FSKConfig,
@@ -257,7 +221,7 @@ def cmd_tx(args):
     meta = tx_obj["meta"]
     info = {
         "mode": "tx",
-        "timestamp": _now_iso(),
+        "timestamp": now_iso_utc(),
         "wav": str(wav_path),
         "config": {
             "fs": cfg.fs,
@@ -491,7 +455,7 @@ def cmd_rx(args):
     # Create overall results
     top = {
         "mode": "rx",
-        "timestamp": _now_iso(),
+        "timestamp": now_iso_utc(),
         "wav": args.wav,
         "config": {
             "fs": cfg.fs,

--- a/analysis/test_clock_recovery/fsk_common.py
+++ b/analysis/test_clock_recovery/fsk_common.py
@@ -1,0 +1,50 @@
+"""Shared utilities for FSK analysis CLIs."""
+
+from __future__ import annotations
+
+import datetime
+import json
+from pathlib import Path
+
+import numpy as np
+
+try:
+    import soundfile as sf
+except ImportError:
+    sf = None
+
+
+def now_iso_utc() -> str:
+    ts = datetime.datetime.now(datetime.UTC)
+    return ts.isoformat().replace("+00:00", "Z")
+
+
+def write_wav(path: Path, data: np.ndarray, fs: int) -> None:
+    if sf is None:
+        from scipy.io import wavfile
+
+        wavfile.write(str(path), fs, data.astype(np.float32))
+    else:
+        sf.write(str(path), data.astype(np.float32), fs)
+
+
+def read_wav(path: Path) -> tuple[int, np.ndarray]:
+    if sf is None:
+        from scipy.io import wavfile
+
+        fs, x = wavfile.read(str(path))
+        if x.dtype != np.float32:
+            denom = np.max(np.abs(x))
+            if denom == 0:
+                denom = 1.0
+            x = x.astype(np.float32) / denom
+    else:
+        x, fs = sf.read(str(path), dtype="float32")
+        if x.ndim > 1:
+            x = x[:, 0]
+    return fs, x.astype(np.float32)
+
+
+def save_json(path: Path, obj) -> None:
+    with open(path, "w") as fh:
+        json.dump(obj, fh, indent=2)


### PR DESCRIPTION
### Motivation
- Provide a dedicated offline tool to inspect per-window CFAR behavior (detection band, guard band, noise band) for FSK packet detection to aid parameter selection and article-quality analysis.
- Factor common CFAR math and IO utilities so the detector and multiple CLIs share the same implementation and outputs for consistent analysis.

### Description
- Add `analysis/test_clock_recovery/fsk_cfar_cli.py`, a new CLI that analyzes a WAV over a user-selected region (start/end or center/span in time or samples) and emits per-window metrics, a focus-window bin-level CSV, a summary JSON, and optional Plotly visualizations including `alpha` vs `Pfa` sweeps and band bin plots.
- Add `analysis/test_clock_recovery/fsk_cfar.py` which factors CFAR logic into `ca_cfar_alpha` and `analyze_cfar_window` to compute detection/stat/threshold, partition bins into detection/guard/noise bands, and return their values for downstream reporting.
- Add `analysis/test_clock_recovery/fsk_common.py` with shared CLI utilities `read_wav`, `write_wav`, `save_json`, and `now_iso_utc` to avoid duplication between CLIs.
- Update `analysis/test_clock_recovery/fsk_baseline.py` to call the shared CFAR helper inside `detect_packet` and route `_ca_cfar_alpha` to the shared `ca_cfar_alpha`, keeping detector behavior consistent with analysis outputs.
- Update `analysis/test_clock_recovery/fsk_cli.py` to use the shared IO/timestamp helpers from `fsk_common`.

### Testing
- Compiled the modified modules with `python -m py_compile analysis/test_clock_recovery/fsk_baseline.py analysis/test_clock_recovery/fsk_cli.py analysis/test_clock_recovery/fsk_common.py analysis/test_clock_recovery/fsk_cfar.py analysis/test_clock_recovery/fsk_cfar_cli.py` (succeeded).
- Exercised TX generation using `python analysis/test_clock_recovery/fsk_cli.py tx --out-base /tmp/fsk_test --plots none --seed 1 --snr-db 20`, which produced `/tmp/fsk_test.wav` and `/tmp/fsk_test.json` (succeeded).
- Ran CFAR analysis using `python analysis/test_clock_recovery/fsk_cfar_cli.py --wav /tmp/fsk_test.wav --out-base /tmp/fsk_test_cfar --center-time 0.6 --span-time 0.8 --plots html`, which wrote the `.json`, `.windows.csv`, `.focus_bins.csv`, and plot outputs for the requested region (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699915e3012c832f846a68794644acbd)