### PR TITLE
Improve CFAR plot readability in fsk_cfar_cli

### DIFF
--- a/analysis/test_clock_recovery/fsk_cfar_cli.py
+++ b/analysis/test_clock_recovery/fsk_cfar_cli.py
@@ -167,12 +167,32 @@ def run_analysis(args):
 
         pfa_vals = np.logspace(np.log10(args.pfa_min), np.log10(args.pfa_max), args.pfa_points)
         ntrain = int(cfar["noise_bins"].size)
-        fig.add_trace(go.Scatter(x=pfa_vals, y=[ca_cfar_alpha(p, ntrain, m_sig=1) for p in pfa_vals], name="alpha m=1"), row=3, col=1)
-        fig.add_trace(go.Scatter(x=pfa_vals, y=[ca_cfar_alpha(p, ntrain, m_sig=2) for p in pfa_vals], name="alpha m=2"), row=3, col=1)
+        fig.add_trace(
+            go.Scatter(
+                x=pfa_vals,
+                y=[ca_cfar_alpha(p, ntrain, m_sig=1) for p in pfa_vals],
+                name="alpha m=1",
+                mode="lines+markers",
+            ),
+            row=3,
+            col=1,
+        )
+        fig.add_trace(
+            go.Scatter(
+                x=pfa_vals,
+                y=[ca_cfar_alpha(p, ntrain, m_sig=2) for p in pfa_vals],
+                name="alpha m=2",
+                mode="lines+markers",
+            ),
+            row=3,
+            col=1,
+        )
         fig.update_xaxes(type="log", row=3, col=1, title_text="Pfa")
         fig.update_yaxes(title_text="alpha", row=3, col=1)
         fig.update_xaxes(title_text="time (s)", row=1, col=1)
+        fig.update_yaxes(title_text="power (linear)", row=1, col=1)
         fig.update_xaxes(title_text="FFT bin", row=2, col=1)
+        fig.update_yaxes(title_text="FFT bin power (linear)", row=2, col=1)
         fig.update_layout(title="FSK CFAR Analysis", height=1000)
 
         if args.plots == "html":


### PR DESCRIPTION
### Motivation
- Make the CFAR analysis plots easier to interpret by adding axis labels with units and explicitly showing sampled alpha points on the alpha-vs-Pfa curve.

### Description
- Add y-axis label `power (linear)` for the "CFAR statistic vs threshold" subplot and `FFT bin power (linear)` for the "Focus window FFT bins by CFAR band" subplot.
- Update the "alpha vs Pfa" traces to use `mode="lines+markers"` for both `m_sig=1` and `m_sig=2` so each computed alpha sample is shown as a marker on the plotted lines.

### Testing
- Ran `python -m py_compile analysis/test_clock_recovery/fsk_cfar_cli.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b2f7265fc832f9b064906bbda2eed)