### PR TITLE
Add heatmap customization flags to FSK CFAR CLI

### DIFF
--- a/analysis/test_clock_recovery/fsk_cfar_cli.py
+++ b/analysis/test_clock_recovery/fsk_cfar_cli.py
@@ -112,7 +112,7 @@ def run_analysis(args):
         # Convert linear power to dB for better visibility of noise vs signal.
         # Avoid -inf by flooring at a small positive value.
         eps = 1e-12
-        Z_vis = 10.0 * np.log10(np.maximum(Z_heatmap, eps))
+        Z_vis = 10.0 * np.log10(Z_heatmap + eps)
         heatmap_units = "dB"
         heatmap_colorbar_title = "Power (dB)"
     else:
@@ -197,6 +197,9 @@ def run_analysis(args):
                 x=t,
                 y=heatmap_y,
                 z=Z_vis,
+                colorscale=args.heatmap_colorscale,
+                zmin=args.heatmap_zmin,
+                zmax=args.heatmap_zmax,
                 colorbar=dict(title=heatmap_colorbar_title),
                 name="fft_power",
                 hovertemplate=(
@@ -278,12 +281,18 @@ def parse_args(argv=None):
 
     p.add_argument("--frequency-axis", action="store_true", help="Use frequency (Hz) instead of FFT bin index for heatmap y-axis")
     p.add_argument("--heatmap-db", action="store_true", help="Plot CFAR bin-power heatmap in dB (10*log10) instead of linear")
+    p.add_argument("--heatmap-colorscale", default="Viridis", help="Plotly colorscale name for CFAR heatmap")
+    p.add_argument("--heatmap-zmin", type=float, default=None, help="Lower color scale bound for heatmap")
+    p.add_argument("--heatmap-zmax", type=float, default=None, help="Upper color scale bound for heatmap")
 
     p.add_argument("--pfa-min", type=float, default=1e-7)
     p.add_argument("--pfa-max", type=float, default=1e-1)
     p.add_argument("--pfa-points", type=int, default=60)
     p.add_argument("--plots", choices=["none", "html", "png"], default="html")
-    return p.parse_args(argv)
+    args = p.parse_args(argv)
+    if args.heatmap_zmin is not None and args.heatmap_zmax is not None and not (args.heatmap_zmin < args.heatmap_zmax):
+        raise ValueError("Invalid heatmap range: --heatmap-zmin must be less than --heatmap-zmax.")
+    return args
 
 
 def main(argv=None):


### PR DESCRIPTION
### Motivation
- Provide users control over CFAR heatmap appearance so visualizations can be tuned for different datasets and publication needs.
- Allow explicit color scaling and dB display so low-level noise and large signals can both be visualized effectively.

### Description
- Add CLI options `--heatmap-colorscale`, `--heatmap-zmin`, and `--heatmap-zmax` in `parse_args()` for configuring the Plotly heatmap colorscale and explicit z-range bounds.
- Validate that when both `--heatmap-zmin` and `--heatmap-zmax` are provided `zmin < zmax` and raise a friendly `ValueError` otherwise.
- Pass the new parameters into the Plotly call as `go.Heatmap(colorscale=..., zmin=..., zmax=...)` so user settings control rendering.
- When `--heatmap-db` is enabled, convert linear power with `10*log10(power + eps)` and keep the colorbar labeled as `Power (dB)`.

### Testing
- Ran `python -m py_compile analysis/test_clock_recovery/fsk_cfar_cli.py` which completed successfully.
- Ran `python analysis/test_clock_recovery/fsk_cfar_cli.py --help` to ensure the new flags appear in the help output and it succeeded.
- Invoked `parse_args()` directly with `PYTHONPATH=analysis/test_clock_recovery` and confirmed that providing `--heatmap-zmin 1 --heatmap-zmax 0` raises the expected `ValueError` with the friendly message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b3cd6fbd4832fa57c21083291e675)