### PR TITLE
Adjust CFAR subplot layout to prioritize heatmap readability

### DIFF
--- a/analysis/test_clock_recovery/fsk_cfar_cli.py
+++ b/analysis/test_clock_recovery/fsk_cfar_cli.py
@@ -182,12 +182,18 @@ def run_analysis(args):
             fh.write(f"{int(b)},{float(v):.9f},detect\n")
 
     if args.plots != "none" and go is not None and make_subplots is not None:
-        fig = make_subplots(rows=4, cols=1, vertical_spacing=0.08, subplot_titles=(
-            "CFAR statistic vs threshold",
-            "CFAR FFT Bin Power vs Time",
-            "Focus window FFT bins by CFAR band",
-            "alpha vs Pfa",
-        ))
+        fig = make_subplots(
+            rows=4,
+            cols=1,
+            row_heights=[0.18, 0.46, 0.2, 0.16],
+            vertical_spacing=0.045,
+            subplot_titles=(
+                "CFAR statistic vs threshold",
+                "CFAR FFT Bin Power vs Time",
+                "Focus window FFT bins by CFAR band",
+                "alpha vs Pfa",
+            ),
+        )
         fig.add_trace(go.Scatter(x=t, y=[r["stat"] for r in rows], name="stat", mode="lines+markers"), row=1, col=1)
         fig.add_trace(go.Scatter(x=t, y=[r["threshold"] for r in rows], name="threshold", mode="lines+markers"), row=1, col=1)
         fig.add_vline(x=focus["idx_center"] / fs, line_dash="dot", line_color="black", row=1, col=1)
@@ -246,7 +252,7 @@ def run_analysis(args):
         fig.update_yaxes(title_text=heatmap_y_label, row=2, col=1)
         fig.update_xaxes(title_text="FFT bin", row=3, col=1)
         fig.update_yaxes(title_text="FFT bin power (linear)", row=3, col=1)
-        fig.update_layout(title="FSK CFAR Bin Power Over Time", height=1300)
+        fig.update_layout(title="FSK CFAR Bin Power Over Time", height=1360)
 
         if args.plots == "html":
             fig.write_html(str(base.with_suffix(".plot.html")), include_plotlyjs="cdn", full_html=True)


### PR DESCRIPTION
### Motivation
- The CFAR heatmap panel was visually crowded in the stacked subplots and needed a larger vertical share so the heatmap and axis labels remain legible. 
- The change aims to rebalance subplot heights and overall figure sizing while keeping the existing diagnostic panels intact.

### Description
- Updated `run_analysis(args)` subplot creation in `analysis/test_clock_recovery/fsk_cfar_cli.py` to call `make_subplots` with `rows=4`, explicit `row_heights=[0.18, 0.46, 0.2, 0.16]`, and reduced `vertical_spacing=0.045` so the heatmap gets the largest share. 
- Increased the overall figure height from `1300` to `1360` via `fig.update_layout(...)` to improve label and trace readability. 
- Left the existing panels unchanged: `CFAR statistic vs threshold`, `CFAR FFT Bin Power vs Time` (heatmap), `Focus window FFT bins by CFAR band`, and `alpha vs Pfa`.

### Testing
- Ran the CLI HTML export with `--plots html` against a generated WAV input and confirmed `base.plot.html` was produced and contains all four subplot titles and the updated `height` value. 
- Attempted PNG export with `--plots png`, which failed in this environment due to Kaleido requiring Chrome (`ChromeNotFoundError`), and the failure is an environment limitation rather than a code error. 
- No unit tests were modified; only the plotting layout code in `run_analysis` was changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b3e7d5938832fa1d4793c3f200352)